### PR TITLE
Minor stoff

### DIFF
--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -226,6 +226,7 @@ xcopy /syi "$(SolutionDir)libs\tbb\bin\*.pdb" "$(SolutionDir)build\$(Platform)\$
     <None Include="Resources\Data\Enemies\Wave.lw" />
     <None Include="Resources\Data\Highscore.lw" />
     <None Include="Resources\Data\Menu.lw" />
+    <None Include="Resources\Data\Upgrades.lw" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="Resources\data\Text.lw" />

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -67,6 +67,7 @@
     <None Include="Resources\Data\Cards.lw" />
     <None Include="Resources\Data\Highscore.lw" />
     <None Include="Resources\Data\Enemies\Wave.lw" />
+    <None Include="Resources\Data\Upgrades.lw" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="Resources\data\Text.lw" />

--- a/Engine/Resources/Data/Highscore.lw
+++ b/Engine/Resources/Data/Highscore.lw
@@ -16,7 +16,7 @@
 }
 {
 	"Player": "Stockman";
-	"Score": 0f;
+	"Score": 5f;
 }
 {
 	"Player": "Stockman";

--- a/Engine/Resources/Data/Upgrades.lw
+++ b/Engine/Resources/Data/Upgrades.lw
@@ -1,0 +1,16 @@
+{ // BOUNCE
+	"flags": 129; // 0x1 + 0x80
+	"increaseCooldown" : 0f;
+	"increaseDamage" : 0;
+	"increaseSize" : 0;
+	"increaseAmmoCap" : 0;
+	"increaseMagSize" : 0;
+}
+{ // AMMO +10
+	"flags": 33; // 0x1 + 0x20
+	"increaseCooldown" : 0f;
+	"increaseDamage" : 0;
+	"increaseSize" : 0;
+	"increaseAmmoCap" : 10;
+	"increaseMagSize" : 0;
+}

--- a/Logic/include/AI/Enemy.h
+++ b/Logic/include/AI/Enemy.h
@@ -32,7 +32,10 @@ namespace Logic
             // the showcase at PAX East will go bad
             int m_nrOfCallbacksEntities;
 
-			float m_health, m_maxHealth, m_baseDamage, m_moveSpeed; // Base
+            // base
+            int m_health, m_maxHealth, m_baseDamage;
+            float m_moveSpeed;
+
 			float m_bulletTimeMod;									// Variables for effect modifiers
             float m_moveSpeedMod;
 			ENEMY_TYPE m_enemyType;
@@ -41,7 +44,7 @@ namespace Logic
 		public:	
 			enum BEHAVIOR_ID { TEST, RANGED, MELEE };
 
-			Enemy(Graphics::ModelID modelID, btRigidBody* body, btVector3 halfExtent, float maxHealth, float baseDamage, float moveSpeed, ENEMY_TYPE enemyType, int animationId);
+			Enemy(Graphics::ModelID modelID, btRigidBody* body, btVector3 halfExtent, int maxHealth, int baseDamage, float moveSpeed, ENEMY_TYPE enemyType, int animationId);
 			virtual ~Enemy();
 
 			virtual void update(Player const &player, float deltaTime,
@@ -61,13 +64,14 @@ namespace Logic
             void decreaseCallbackEntities();
             bool hasCallbackEntities();
 
-			void damage(float damage);
+			void damage(int damage);
 			void setBehavior(BEHAVIOR_ID id);
 			void setEnemyType(ENEMY_TYPE id);
 
-			float getHealth() const;
-			float getMaxHealth() const;
-			float getBaseDamage() const;
+            int getHealth() const;
+            int getMaxHealth() const;
+            int getBaseDamage() const;
+
 			float getMoveSpeed() const;
 			ENEMY_TYPE getEnemyType() const;
 			Behavior* getBehavior() const;

--- a/Logic/include/AI/EnemyChaser.h
+++ b/Logic/include/AI/EnemyChaser.h
@@ -8,7 +8,8 @@ namespace Logic
     class EnemyChaser : public Enemy
     {
     private:
-        static const float MAX_HP, BASE_DAMAGE, MOVE_SPEED;
+        static const int MAX_HP, BASE_DAMAGE;
+        static const float MOVE_SPEED;
     public:
         EnemyChaser(btRigidBody* body);
         ~EnemyChaser();

--- a/Logic/include/AI/EnemyNecromancer.h
+++ b/Logic/include/AI/EnemyNecromancer.h
@@ -10,7 +10,9 @@ namespace Logic
 	{
 		private:
             int m_spawnedMinions;
-			const int SPEED_AB1 = 15, SPEED_AB2 = 25, MAX_SPAWNED_MINIONS = 4;
+            static const float BASE_SPEED;
+            static const int BASE_DAMAGE, MAX_HP;
+			static const int SPEED_AB1, SPEED_AB2, MAX_SPAWNED_MINIONS;
 		public:
 			EnemyNecromancer(Graphics::ModelID modelID, btRigidBody* body, btVector3 halfExtent);
 			virtual ~EnemyNecromancer();

--- a/Logic/include/Entity/Upgrade.h
+++ b/Logic/include/Entity/Upgrade.h
@@ -30,11 +30,11 @@ namespace Logic
 		};
 
 		struct FlatUpgrades {
-			float increaseDmg;
 			float increaseCooldown;
-			float increaseSize;
-			float increaseAmmoCap;
-			float increaseMagSize;
+            int increaseDmg;
+            int increaseSize;
+			int increaseAmmoCap;
+            int increaseMagSize;
 		};
 
 		Upgrade();

--- a/Logic/include/Projectile/Projectile.h
+++ b/Logic/include/Projectile/Projectile.h
@@ -11,7 +11,7 @@ namespace Logic
 	public:
 
 		Projectile(btRigidBody* body, btVector3 halfExtent);
-		Projectile(btRigidBody* body, btVector3 halfExtent, float damage, float speed, float gravityModifer, float ttl);
+		Projectile(btRigidBody* body, btVector3 halfExtent, int damage, float speed, float gravityModifer, float ttl);
 		Projectile(btRigidBody* body, btVector3 halfExtent, ProjectileData pData);
 		Projectile(const Projectile& other) = delete;
 		Projectile* operator=(const Projectile& other) = delete;

--- a/Logic/include/Projectile/ProjectileStruct.h
+++ b/Logic/include/Projectile/ProjectileStruct.h
@@ -19,7 +19,7 @@ namespace Logic
 
 	struct ProjectileData
 	{
-		float damage;				// Projectile Damage
+		int damage;				// Projectile Damage
 		float scale;				// Scale of the projectile
 		float mass;					// Mass of projectile
 		float speed;				// Bullet speed
@@ -33,8 +33,8 @@ namespace Logic
 		bool isSensor;				// If bullet is sensor or not (collision with other bullet)
 		bool enemyBullet;			// if enemies shot it or a player
 
-		ProjectileData() : damage(1.f), scale(1.f), mass(1.f), speed(1.f), gravityModifier(0.f), ttl(1000), meshID(Graphics::ModelID::CUBE), materialID(1), type(ProjectileTypeNormal), isSensor(false), enemyBullet(false) {}
-		ProjectileData(float inDamage, float inScale, float inMass, float inSpeed, float inGravityModifier, float inTTL, Graphics::ModelID inMeshID, int inMaterialID, ProjectileType inType = ProjectileTypeNormal, bool inIsSensor = false, bool inEnemyBullet = false) : damage(inDamage), scale(inScale), mass(inMass), speed(inSpeed),
+		ProjectileData() : damage(1), scale(1.f), mass(1.f), speed(1.f), gravityModifier(0.f), ttl(1000), meshID(Graphics::ModelID::CUBE), materialID(1), type(ProjectileTypeNormal), isSensor(false), enemyBullet(false) {}
+		ProjectileData(int inDamage, float inScale, float inMass, float inSpeed, float inGravityModifier, float inTTL, Graphics::ModelID inMeshID, int inMaterialID, ProjectileType inType = ProjectileTypeNormal, bool inIsSensor = false, bool inEnemyBullet = false) : damage(inDamage), scale(inScale), mass(inMass), speed(inSpeed),
 			gravityModifier(inGravityModifier), ttl(inTTL), meshID(inMeshID), materialID(inMaterialID), type(inType), isSensor(inIsSensor), enemyBullet(inEnemyBullet) {}
 	};
 }

--- a/Logic/source/AI/Enemy.cpp
+++ b/Logic/source/AI/Enemy.cpp
@@ -9,7 +9,7 @@
 
 using namespace Logic;
 
-Enemy::Enemy(Graphics::ModelID modelID, btRigidBody* body, btVector3 halfExtent, float health, float baseDamage, float moveSpeed, ENEMY_TYPE enemyType, int animationId)
+Enemy::Enemy(Graphics::ModelID modelID, btRigidBody* body, btVector3 halfExtent, int health, int baseDamage, float moveSpeed, ENEMY_TYPE enemyType, int animationId)
 : Entity(body, halfExtent, modelID)
 {
 	m_behavior = nullptr;
@@ -88,7 +88,7 @@ bool Enemy::hasCallbackEntities()
     return m_nrOfCallbacksEntities > 0;
 }
 
-void Enemy::damage(float damage)
+void Enemy::damage(int damage)
 {
 	m_health -= damage;
 
@@ -104,24 +104,24 @@ void Enemy::affect(int stacks, Effect const &effect, float dt)
 	if (flags & Effect::EFFECT_KILL)
 		damage(m_health);
 	if (flags & Effect::EFFECT_ON_FIRE)
-		damage(effect.getModifiers()->modifyDmgTaken * dt);
+		damage(static_cast<int> (effect.getModifiers()->modifyDmgTaken * dt));
 	if (flags & Effect::EFFECT_BULLET_TIME)
 		m_bulletTimeMod *= std::pow(effect.getSpecifics()->isBulletTime, stacks);
     if (flags & Effect::EFFECT_IS_FROZEN)
         m_moveSpeedMod *= std::pow(effect.getSpecifics()->isFreezing, stacks);
 }
 
-float Enemy::getHealth() const
+int Enemy::getHealth() const
 {
 	return m_health;
 }
 
-float Enemy::getMaxHealth() const
+int Enemy::getMaxHealth() const
 {
 	return m_maxHealth;
 }
 
-float Enemy::getBaseDamage() const
+int Enemy::getBaseDamage() const
 {
 	return m_baseDamage;
 }

--- a/Logic/source/AI/EnemyChaser.cpp
+++ b/Logic/source/AI/EnemyChaser.cpp
@@ -3,8 +3,8 @@
 #include <Projectile\Projectile.h>
 using namespace Logic;
 
-const float EnemyChaser::MAX_HP = 3;
-const float EnemyChaser::BASE_DAMAGE = 1;
+const int EnemyChaser::MAX_HP = 3;
+const int EnemyChaser::BASE_DAMAGE = 1;
 const float EnemyChaser::MOVE_SPEED = 13;
 
 EnemyChaser::EnemyChaser(btRigidBody* body)
@@ -25,7 +25,7 @@ void EnemyChaser::onCollision(PhysicsObject& other, btVector3 contactPoint, floa
         {
             if (!pj->getProjectileData().enemyBullet)
             {
-                damage(pj->getProjectileData().damage * dmgMultiplier);
+                damage(static_cast<int> (pj->getProjectileData().damage * dmgMultiplier));
 
                 if (pj->getProjectileData().type == ProjectileTypeBulletTimeSensor)
                     getStatusManager().addStatus(StatusManager::EFFECT_ID::BULLET_TIME, pj->getStatusManager().getStacksOfEffectFlag(Effect::EFFECT_FLAG::EFFECT_BULLET_TIME), true);

--- a/Logic/source/AI/EnemyNecromancer.cpp
+++ b/Logic/source/AI/EnemyNecromancer.cpp
@@ -3,12 +3,18 @@
 #include <Misc\RandomGenerator.h>
 #include <Projectile\Projectile.h>
 #include <Misc\ComboMachine.h>
-
 using namespace Logic;
+
+const int EnemyNecromancer::SPEED_AB1 = 15,
+          EnemyNecromancer::SPEED_AB2 = 25,
+          EnemyNecromancer::MAX_SPAWNED_MINIONS = 4,
+          EnemyNecromancer::BASE_DAMAGE = 1,
+          EnemyNecromancer::MAX_HP = 4;
+const float EnemyNecromancer::BASE_SPEED = 8.f;
 
 EnemyNecromancer::EnemyNecromancer(Graphics::ModelID modelID,
     btRigidBody* body, btVector3 halfExtent)
-    : Enemy(modelID, body, halfExtent, 5, 1, 8, NECROMANCER, 0) {
+    : Enemy(modelID, body, halfExtent, MAX_HP, BASE_DAMAGE, BASE_SPEED, NECROMANCER, 0) {
     setBehavior(RANGED);
     addCallback(ON_DEATH, [&](CallbackData data) -> void {
         ComboMachine::Get().Kill(getEnemyType());
@@ -34,7 +40,7 @@ void EnemyNecromancer::onCollision(PhysicsObject& other, btVector3 contactPoint,
     {
         if (!pj->getProjectileData().enemyBullet)
         {
-            damage(pj->getProjectileData().damage * dmgMultiplier);
+            damage(static_cast<int> (pj->getProjectileData().damage * dmgMultiplier));
 
             if (pj->getProjectileData().type == ProjectileTypeBulletTimeSensor)
                 getStatusManager().addStatus(StatusManager::EFFECT_ID::BULLET_TIME, pj->getStatusManager().getStacksOfEffectFlag(Effect::EFFECT_FLAG::EFFECT_BULLET_TIME), true);

--- a/Logic/source/Entity/Entity.cpp
+++ b/Logic/source/Entity/Entity.cpp
@@ -75,9 +75,16 @@ void Entity::clearCallbacks()
 
 void Entity::callback(EntityEvent entityEvent, CallbackData &data)
 {
-    if (hasCallback(entityEvent))
-        for (Callback &callback : m_callbacks[entityEvent])
-            callback(data);
+    try
+    {
+        if (hasCallback(entityEvent))
+            for (Callback &callback : m_callbacks[entityEvent])
+                callback(data);
+    }
+    catch (std::exception ex)
+    {
+        printf("Callback error (Probably null callback data) \n%s\n", ex.what());
+    }
 }
 
 StatusManager& Entity::getStatusManager()

--- a/Logic/source/Entity/StatusManager.cpp
+++ b/Logic/source/Entity/StatusManager.cpp
@@ -2,7 +2,8 @@
 #include <stdio.h>
 #include <Misc/FileLoader.h>
 
-#define FILE_NAME "Effects"
+#define FILE_NAME_EFFECTS "Effects"
+#define FILE_NAME_UPGRADES "Upgrades"
 
 using namespace Logic;
 
@@ -11,69 +12,77 @@ Upgrade StatusManager::s_upgrades[StatusManager::NR_OF_UPGRADES];
  
 StatusManager::StatusManager() 
 { 
-	#ifndef BUFFS_CREATED
-	#define BUFFS_CREATED
-		std::vector<FileLoader::LoadedStruct> loadedEffects;
-		FileLoader::singleton().loadStructsFromFile(loadedEffects, FILE_NAME);
-		Effect::Standards standards;
-		Effect::Modifiers modifiers;
-		Effect::Specifics spec;
-		int id = 0;
+    static bool statusesCreated = false;
+    if (!statusesCreated)
+    {
+        statusesCreated = true;
 
-		for (auto const &fileStruct : loadedEffects)
-		{
-			Effect creating;
+        {
+            // CREATE EFFECTS
+            std::vector<FileLoader::LoadedStruct> loadedEffects;
+            FileLoader::singleton().loadStructsFromFile(loadedEffects, FILE_NAME_EFFECTS);
+            Effect::Standards standards;
+            Effect::Modifiers modifiers;
+            Effect::Specifics spec;
+            int id = 0;
 
-			standards.flags = fileStruct.ints.at("flags");
-			standards.duration = fileStruct.floats.at("duration");
+            for (auto const &fileStruct : loadedEffects)
+            {
+                Effect creating;
 
-			if (fileStruct.ints.at("modifiers"))
-			{
-				memset(&modifiers, 0, sizeof(modifiers));
+                standards.flags = fileStruct.ints.at("flags");
+                standards.duration = fileStruct.floats.at("duration");
 
-				modifiers.modifyDmgGiven =		fileStruct.floats.at("mDmgGiven");
-				modifiers.modifyDmgTaken =		fileStruct.floats.at("mDmgTaken");
-				modifiers.modifyFirerate =		fileStruct.floats.at("mFirerate");
-				modifiers.modifyHP =			fileStruct.floats.at("mHP");
-				modifiers.modifyMovementSpeed = fileStruct.floats.at("mMovementSpeed");
+                if (fileStruct.ints.at("modifiers"))
+                {
+                    memset(&modifiers, 0, sizeof(modifiers));
 
-				creating.setModifiers(modifiers);
-			}
+                    modifiers.modifyDmgGiven = fileStruct.floats.at("mDmgGiven");
+                    modifiers.modifyDmgTaken = fileStruct.floats.at("mDmgTaken");
+                    modifiers.modifyFirerate = fileStruct.floats.at("mFirerate");
+                    modifiers.modifyHP = fileStruct.floats.at("mHP");
+                    modifiers.modifyMovementSpeed = fileStruct.floats.at("mMovementSpeed");
 
-			if (fileStruct.ints.at("specifics"))
-			{
-				memset(&spec, 0, sizeof(spec));
-			
-				spec.isBulletTime = fileStruct.floats.at("sBulletTime");
-				spec.isFreezing =	fileStruct.floats.at("sFreezing");
-                spec.ammoType =     fileStruct.floats.at("sAmmoType");
+                    creating.setModifiers(modifiers);
+                }
 
-				creating.setSpecifics(spec);
-			}
+                if (fileStruct.ints.at("specifics"))
+                {
+                    memset(&spec, 0, sizeof(spec));
 
-			creating.setStandards(standards);
-			s_effects[id++] = creating;
-		}
-	#endif // !buffsCreated
+                    spec.isBulletTime = fileStruct.floats.at("sBulletTime");
+                    spec.isFreezing = fileStruct.floats.at("sFreezing");
+                    spec.ammoType = fileStruct.floats.at("sAmmoType");
 
-	#ifndef UPGRADES_CREATED
-	#define UPGRADES_CREATED
-	/* THIS IS A TEMPORARY TEST SOLUTION, MOVE TO OTHER CLASS LATER (OR FILE?) */
-			Upgrade upgrade;
-			Upgrade::FlatUpgrades flat;
-			memset(&flat, 0, sizeof(flat));
+                    creating.setSpecifics(spec);
+                }
 
-			upgrade.init(Upgrade::UPGRADE_IS_WEAPON | Upgrade::UPGRADE_IS_BOUNCING,
-						 0, flat);
-			s_upgrades[BOUNCE] = upgrade;
-			memset(&flat, 0, sizeof(flat));
+                creating.setStandards(standards);
+                s_effects[id++] = creating;
+            }
+        }
 
-			flat.increaseAmmoCap = 10;
-			upgrade.init(Upgrade::UPGRADE_IS_WEAPON | Upgrade::UPGRADE_INCREASE_AMMOCAP,
-						0, flat);
-			s_upgrades[P10_AMMO] = upgrade; // FREEZE
-			memset(&flat, 0, sizeof(flat));
-	#endif // !UPGRADES_CREATED
+        {
+            // CREATE UPGRADES
+            long long flags;
+            Upgrade::FlatUpgrades flat;
+            std::vector<FileLoader::LoadedStruct> loadedUpgrades;
+
+            FileLoader::singleton().loadStructsFromFile(loadedUpgrades, FILE_NAME_UPGRADES);
+            int id = 0;
+
+            for (auto const &fileStruct : loadedUpgrades)
+            {
+                flags                   = fileStruct.ints.at("flags");
+                flat.increaseCooldown   = fileStruct.floats.at("increaseCooldown");
+                flat.increaseDmg        = fileStruct.ints.at("increaseDamage");
+                flat.increaseAmmoCap    = fileStruct.ints.at("increaseAmmoCap");
+                flat.increaseMagSize    = fileStruct.ints.at("increaseMagSize");
+                flat.increaseSize       = fileStruct.ints.at("increaseSize");
+                s_upgrades[id].init(flags, id++, flat);
+            }
+        }
+    }
 }
 
 StatusManager::~StatusManager() {

--- a/Logic/source/Entity/StatusManager.cpp
+++ b/Logic/source/Entity/StatusManager.cpp
@@ -33,8 +33,6 @@ StatusManager::StatusManager()
                 flat.increaseAmmoCap = fileStruct.ints.at("increaseAmmoCap");
                 flat.increaseMagSize = fileStruct.ints.at("increaseMagSize");
                 flat.increaseSize = fileStruct.ints.at("increaseSize");
-                if (id >= NR_OF_UPGRADES)
-                    printf("FUUCK");
                 s_upgrades[id].init(flags, id, flat);
                 id++;
             }

--- a/Logic/source/Entity/StatusManager.cpp
+++ b/Logic/source/Entity/StatusManager.cpp
@@ -16,6 +16,29 @@ StatusManager::StatusManager()
     if (!statusesCreated)
     {
         statusesCreated = true;
+        {
+            // CREATE UPGRADES
+            long long flags;
+            Upgrade::FlatUpgrades flat;
+            std::vector<FileLoader::LoadedStruct> loadedUpgrades;
+
+            FileLoader::singleton().loadStructsFromFile(loadedUpgrades, FILE_NAME_UPGRADES);
+            int id = 0;
+
+            for (auto const &fileStruct : loadedUpgrades)
+            {
+                flags = fileStruct.ints.at("flags");
+                flat.increaseCooldown = fileStruct.floats.at("increaseCooldown");
+                flat.increaseDmg = fileStruct.ints.at("increaseDamage");
+                flat.increaseAmmoCap = fileStruct.ints.at("increaseAmmoCap");
+                flat.increaseMagSize = fileStruct.ints.at("increaseMagSize");
+                flat.increaseSize = fileStruct.ints.at("increaseSize");
+                if (id >= NR_OF_UPGRADES)
+                    printf("FUUCK");
+                s_upgrades[id].init(flags, id, flat);
+                id++;
+            }
+        }
 
         {
             // CREATE EFFECTS
@@ -58,28 +81,8 @@ StatusManager::StatusManager()
                 }
 
                 creating.setStandards(standards);
-                s_effects[id++] = creating;
-            }
-        }
-
-        {
-            // CREATE UPGRADES
-            long long flags;
-            Upgrade::FlatUpgrades flat;
-            std::vector<FileLoader::LoadedStruct> loadedUpgrades;
-
-            FileLoader::singleton().loadStructsFromFile(loadedUpgrades, FILE_NAME_UPGRADES);
-            int id = 0;
-
-            for (auto const &fileStruct : loadedUpgrades)
-            {
-                flags                   = fileStruct.ints.at("flags");
-                flat.increaseCooldown   = fileStruct.floats.at("increaseCooldown");
-                flat.increaseDmg        = fileStruct.ints.at("increaseDamage");
-                flat.increaseAmmoCap    = fileStruct.ints.at("increaseAmmoCap");
-                flat.increaseMagSize    = fileStruct.ints.at("increaseMagSize");
-                flat.increaseSize       = fileStruct.ints.at("increaseSize");
-                s_upgrades[id].init(flags, id++, flat);
+                s_effects[id] = creating;
+                id++;
             }
         }
     }

--- a/Logic/source/Player/Player.cpp
+++ b/Logic/source/Player/Player.cpp
@@ -157,7 +157,7 @@ void Player::onCollision(PhysicsObject& other, btVector3 contactPoint, float dmg
             int stacks = getStatusManager().getStacksOfEffectFlag(Effect::EFFECT_FLAG::EFFECT_CONSTANT_PUSH_BACK);
             e->getRigidBody()->applyCentralForce((getPositionBT() - e->getPositionBT()).normalize() * static_cast<btScalar> (stacks));
             stacks = getStatusManager().getStacksOfEffectFlag(Effect::EFFECT_FLAG::EFFECT_CONSTANT_DAMAGE_ON_CONTACT);
-            e->damage(2.f * stacks); // replace 1 with the player damage when it is better
+            e->damage(2 * stacks); // replace 1 with the player damage when it is better
         }
     }
 }

--- a/Logic/source/Projectile/Projectile.cpp
+++ b/Logic/source/Projectile/Projectile.cpp
@@ -13,7 +13,7 @@ static bool FUN_MODE = false;
 Projectile::Projectile(btRigidBody* body, btVector3 halfextent)
 : Entity(body, halfextent, Graphics::ModelID::SPHERE) 
 {
-	m_pData.damage = 1.f;
+	m_pData.damage = 1;
 	m_pData.speed = 0.f;
 	m_pData.gravityModifier = 1.f;
 	m_pData.ttl = 1000.f;
@@ -21,7 +21,7 @@ Projectile::Projectile(btRigidBody* body, btVector3 halfextent)
 	m_bulletTimeMod = 1.f;
 }
 
-Projectile::Projectile(btRigidBody* body, btVector3 halfExtent, float damage, float speed, float gravityModifer, float ttl)
+Projectile::Projectile(btRigidBody* body, btVector3 halfExtent, int damage, float speed, float gravityModifer, float ttl)
 : Entity(body, halfExtent, Graphics::ModelID::SPHERE)
 {
 	m_pData.damage = damage;


### PR DESCRIPTION
- Damage as ints
- Creating Upgrades
- Necromancer HP reduced from 5 -> 4.
DEVELOPER COMMENT:
The HP was 5 resulting in it being killed by 3 heads shots, this caused a meta of 2 HS + 1 body shot,
this was never intended and should now be 2 HS. This will reduce the round time if you are skilled
enough to get 2 HS instead of 1 HS + 3 BS.