### PR TITLE
alpha from menues

### DIFF
--- a/Graphics/include/RenderPass/GUIRenderPass.h
+++ b/Graphics/include/RenderPass/GUIRenderPass.h
@@ -35,6 +35,7 @@ namespace Graphics
             DirectX::SimpleMath::Vector2 uv;
         };
         StructuredBuffer<Vertex> vertexBuffer;
+        StructuredBuffer<float> alphabuffer;
 
         std::unique_ptr<DirectX::SpriteBatch> sBatch;
         std::unordered_map<Resources::Fonts::Files, std::unique_ptr<DirectX::SpriteFont>> fonts;

--- a/Resources/Shaders/SpriteShader.hlsl
+++ b/Resources/Shaders/SpriteShader.hlsl
@@ -7,13 +7,14 @@ struct Vertex
 
 struct SpriteData
 {
-    float yes;
+    float aplha;
 };
 
 struct Fragment
 {
     float4 position : SV_Position;
     float2 uv : UV;
+    uint spriteIndex : INDEX;
 };
 
 struct Pixel
@@ -42,6 +43,8 @@ Fragment VS(uint vertexId : SV_VertexId)
     fragment.position = float4(vertex.position, 0, 1);
     fragment.uv = vertex.uv;
 
+    fragment.spriteIndex = offset / 4;
+
     return fragment;
 }
 
@@ -51,5 +54,6 @@ Pixel PS(Fragment fragment)
 
     pixel.color = spriteTexture.Sample(linearSampler, fragment.uv);
 
+    pixel.color = float4(pixel.color.xyz, min(pixel.color.w, spriteData[fragment.spriteIndex].aplha));
     return pixel;
 }


### PR DESCRIPTION
The menu sprites alpha is now used if it is less then the textures alpha